### PR TITLE
Fix broken test & update npm script to work on unix systems

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -7,6 +7,7 @@
 		"build": "cross-env NODE_OPTIONS=--no-deprecation nuxt build",
 		"cf-typegen": "wrangler types",
 		"dev": "cls && yarn install && nuxt dev",
+		"dev-unix": "clear && yarn install && nuxt dev",
 		"deploy": "npm run build && wrangler pages deploy",
 		"generate": "nuxt generate",
 		"preview1": "nuxt preview",
@@ -14,7 +15,8 @@
 		"postinstall": "nuxt prepare",
 		"start": "node .output/server/index.mjs",
 		"migrate_db": "supabase db push",
-		"test": "cls && vitest"
+		"test": "cls && vitest",
+		"test-unix": "clear && vitest"
 	},
 	"dependencies": {
 		"@hebilicious/vue-query-nuxt": "0.3.0",

--- a/src/server/utils/authUtils.test.ts
+++ b/src/server/utils/authUtils.test.ts
@@ -13,7 +13,7 @@ describe("GeneratePasswordHash", () => {
 
 	it("should generate a hash for a given password", async () => {
 		const password = "password123";
-		const expectedHash = "iLSac0sNdXZ6-S4VUYGi6g"; // Example hash, replace with actual expected hash
+		const expectedHash = "bb66d4e66d707fbc22c4490c50a063fe0bc4ba0b6ce72703378d45725ee28f93"; // Example hash, replace with actual expected hash
 		const hash = await GeneratePasswordHash(password, salt1);
 		expect(hash).toBe(expectedHash);
 	});


### PR DESCRIPTION
Update expected hash for the test that was broken from recent changes. 

I also added a `dev-unix` & `test-unix` script to run on unix systems such as Linux or Macos as the cls command on the originals will only work on Windows.